### PR TITLE
Fix overly exact pin of AppsFlyerFramework version

### DIFF
--- a/PurchaseConnector.podspec
+++ b/PurchaseConnector.podspec
@@ -23,13 +23,13 @@ Pod::Spec.new do |s|
     s.default_subspecs = 'Main'
 
     s.subspec 'Main' do |ss|
-        ss.ios.dependency 'AppsFlyerFramework', "6.10.0"
+        ss.ios.dependency 'AppsFlyerFramework', ">= 6.10.0"
         ss.ios.preserve_paths = 'PurchaseConnector.xcframework'
         ss.ios.vendored_frameworks = 'PurchaseConnector.xcframework'
      end
 
     s.subspec 'Dynamic' do |ss|
-        ss.ios.dependency 'AppsFlyerFramework/Dynamic', "6.10.0"
+        ss.ios.dependency 'AppsFlyerFramework/Dynamic', ">= 6.10.0"
         ss.ios.preserve_paths = 'Dynamic/PurchaseConnector.xcframework'
         ss.ios.vendored_frameworks = 'Dynamic/PurchaseConnector.xcframework'
    end


### PR DESCRIPTION
AppsFlyerFramework is already on 6.10.2, making this pod spec unusable as it is.